### PR TITLE
Normalize SF Street Use permit properties

### DIFF
--- a/lib/spy_glass/registry/sf-street-use.rb
+++ b/lib/spy_glass/registry/sf-street-use.rb
@@ -56,6 +56,7 @@ SpyGlass::Registry << SpyGlass::Client::Socrata.new(opts) do |collection|
         'title' => title,
 
         'type' => permit_types[item['permit_type']],
+        'description' => item['permit_purpose'],
         'originator' => item['agent'],
         'originator_phone' => item['agentphone'],
         'status' => item['status'],

--- a/lib/spy_glass/registry/sf-street-use.rb
+++ b/lib/spy_glass/registry/sf-street-use.rb
@@ -51,7 +51,10 @@ SpyGlass::Registry << SpyGlass::Client::Socrata.new(opts) do |collection|
       # will iterate on this to come up with normalized properties for the custom front-end
       # https://github.com/SFDigitalServices/neighborhood-noticing
       'properties' => {
+        # required by Citygram
         'id' => item['permit_number'],
+        'title' => title,
+
         'type' => permit_types[item['permit_type']],
         'originator' => item['agent'],
         'originator_phone' => item['agentphone'],

--- a/lib/spy_glass/registry/sf-street-use.rb
+++ b/lib/spy_glass/registry/sf-street-use.rb
@@ -1,5 +1,17 @@
 require 'spy_glass/registry'
 
+# load type dictionary
+# creates hash of permit type to description
+permit_types = SpyGlass::Client::Socrata.new({
+  path: '/sf-street-use-types',
+  cache: SpyGlass::Cache::Memory.new(expires_in: 300),
+  content_type: 'application/json',
+  generator: SpyGlass::Client::Base::IDENTITY,
+  source: 'https://data.sfgov.org/resource/kzxg-e2hm.json',
+}) do |collection|
+  Hash[collection.map(&:values)].invert
+end.cooked
+
 opts = {
   path: '/sf-street-use',
   cache: SpyGlass::Cache::Memory.new(expires_in: 300),
@@ -13,14 +25,17 @@ opts = {
   })
 }
 
-puts opts[:source]
-
 SpyGlass::Registry << SpyGlass::Client::Socrata.new(opts) do |collection|
   features = collection.map do |item|
     # TODO handle nil cases better
     title = <<-TITLE.oneline
     A new #{item.fetch('permit_type', '').titleize} permit has been issued at #{item.fetch('permit_address', 'unknown address').titleize} to #{item.fetch('agent', 'unknown').titleize} with id #{item['permit_number']}. Contact #{item['contact']} with any questions.
   TITLE
+
+    location = item['permit_address'] ? item['permit_address'] : item['streetname']
+    if item['cross_street_1'] && item['cross_street_2']
+      location += ", between #{item['cross_street_1']} and #{item['cross_street_2']}"
+    end
 
     {
       'id' => item['permit_number'],
@@ -32,7 +47,18 @@ SpyGlass::Registry << SpyGlass::Client::Socrata.new(opts) do |collection|
           item['latitude'].to_f
         ]
       },
-      'properties' => item.merge('title' => title)
+
+      # will iterate on this to come up with normalized properties for the custom front-end
+      # https://github.com/SFDigitalServices/neighborhood-noticing
+      'properties' => {
+        'type' => permit_types[item['permit_type']],
+        'originator' => item['agent'],
+        'originator_phone' => item['agentphone'],
+        'status' => item['status'],
+        'location' => location,
+        'start' => item['start_date'],
+        'end' => item['end_date'],
+      },
     }
   end
 

--- a/lib/spy_glass/registry/sf-street-use.rb
+++ b/lib/spy_glass/registry/sf-street-use.rb
@@ -51,6 +51,7 @@ SpyGlass::Registry << SpyGlass::Client::Socrata.new(opts) do |collection|
       # will iterate on this to come up with normalized properties for the custom front-end
       # https://github.com/SFDigitalServices/neighborhood-noticing
       'properties' => {
+        'id' => item['permit_number'],
         'type' => permit_types[item['permit_type']],
         'originator' => item['agent'],
         'originator_phone' => item['agentphone'],


### PR DESCRIPTION
Generalize the SF Street-Use permit properties for custom front-end.

Also remove accidental `puts`