### PR TITLE
Fix type name for SF Street Use Boring permit

### DIFF
--- a/lib/spy_glass/registry/sf-street-use.rb
+++ b/lib/spy_glass/registry/sf-street-use.rb
@@ -39,7 +39,7 @@ permit_type_metadata = {
     "description" => "Allows a nonprofit or cultural organization to advertise a City-supported public event on utility poles.",
     "link" => "https://www.sfpublicworks.org/services/permits/banners",
   },
-  "Bicycle" => {
+  "Boring" => {
     "description" => "Allows a licensed contractor to bore or install a monitoring well in a street or sidewalk",
     "link" => "https://www.sfpublicworks.org/services/permits/boring-and-monitoring-well",
   },


### PR DESCRIPTION
This fixes the type name for the boring permit to allow the metadata for this permit to be looked up correctly.